### PR TITLE
Fix default assert check to be deep equal

### DIFF
--- a/initial/js_node
+++ b/initial/js_node
@@ -9,7 +9,7 @@ console.log('Example:')
 console.log(follow("fflff"))
 
 // These "asserts" are used for self-checking and not for an auto-testing
-assert.equal(follow("fflff"), [-1, 4])
-assert.equal(follow("ffrff"), [1, 4])
-assert.equal(follow("fblr"), [0, 0])
+assert.deepEqual(follow("fflff"), [-1, 4])
+assert.deepEqual(follow("ffrff"), [1, 4])
+assert.deepEqual(follow("fblr"), [0, 0])
 console.log("Coding complete? Click 'Check' to earn cool rewards!");


### PR DESCRIPTION
with just assert.equal() you can have the case where [-1, 4] == [-1, 4] fails because they are two different objects, a very confusing message for newcomers to the language